### PR TITLE
Print database name when logging to a file.

### DIFF
--- a/bin/pt-kill
+++ b/bin/pt-kill
@@ -7330,7 +7330,7 @@ sub main {
             if ( $o->get('print') ) {
                printf "# %s %s %d (%s %d sec) %s\n",
                   ts(time), $o->get('kill-query') ? 'KILL QUERY' : 'KILL',
-                  $query->{Id}, ($query->{Command} || 'NULL'), $query->{Time},
+                  $query->{Id}, $query->{db}, ($query->{Command} || 'NULL'), $query->{Time},
                   ($query->{Info} || 'NULL');
             }
             if ( $o->get('query-id') ) {


### PR DESCRIPTION
Related reported bug: https://bugs.launchpad.net/percona-toolkit/+bug/1015804

Example command and output:

```
pt-kill --user=<user> --password=<password> --socket=<socket> --busy-time=20 --interval=15 --print --match-command=Query --daemonize --log <logfile>

# 2019-05-30T10:30:42 KILL 23063482 skyzer (Query 41 sec) SELECT domain FROM domains_data
# 2019-05-30T10:46:57 KILL 23080285 ddb2 (Query 20 sec) SELECT option_name, option_value FROM wp_options WHERE autoload = 'yes'
# 2019-05-30T10:47:12 KILL 23080285 ddb2 (Query 35 sec) SELECT option_name, option_value FROM wp_options WHERE autoload = 'yes'
# 2019-05-30T23:18:30 KILL 24551301 skyzer (Query 27 sec) DELETE FROM domains_data WHERE completed IS NULL
# 2019-05-30T23:22:00 KILL 24559692 skyzer (Query 25 sec) optimize table domains_data
# 2019-05-30T23:23:09 KILL 24559702 alph_co (Query 27 sec) UPDATE fus_settings SET settings_value=settings_value+1 WHERE settings_name='counter'
```